### PR TITLE
Add forceSSL-Service with config-option

### DIFF
--- a/app/app.php
+++ b/app/app.php
@@ -7,6 +7,7 @@ require_once __DIR__.'/../vendor/autoload.php';
 // Config
 $config = array(
     'debug' => true,
+    'forceSSL' => false,
     'timer.start' => $startTime,
     'monolog.name' => 'pwx',
     'monolog.level' => \Monolog\Logger::DEBUG,
@@ -53,7 +54,7 @@ $app['translator'] = $app->share($app->extend('translator', function(\Silex\Tran
 // Register default controller
 $app['app.default_controller'] = $app->share(
     function () use ($app) {
-        return new \App\Controller\DefaultController($app, $app['twig'], $app['credential_service'], $app['request']);
+        return new \App\Controller\DefaultController($app, $app['twig'], $app['credential_service'], $app['forceSSL_service'], $app['request']);
     }
 );
 
@@ -61,6 +62,13 @@ $app['app.default_controller'] = $app->share(
 $app['credential_service'] = $app->share(
     function () use ($app, $config) {
         return new \App\Model\CredentialService($app['db'], $config);
+    }
+);
+
+// Register forceSSL service
+$app['forceSSL_service'] = $app->share(
+    function () use ($app, $config) {
+        return new \App\Model\ForceSSLService($config);
     }
 );
 

--- a/app/config.php.openshift
+++ b/app/config.php.openshift
@@ -1,5 +1,6 @@
 <?php
 $config['debug'] = false;
+$config['forceSSL'] = false;
 
 $config['db.options']['driver'] = 'pdo_mysql';
 $config['db.options']['host'] = getenv('OPENSHIFT_MYSQL_DB_HOST');

--- a/app/config.php.sample
+++ b/app/config.php.sample
@@ -1,5 +1,6 @@
 <?php
 $config['debug'] = false;
+$config['forceSSL'] = true;
 
 $config['db.options']['driver'] = 'pdo_mysql';
 $config['db.options']['host'] = 'localhost';

--- a/src/App/Controller/DefaultController.php
+++ b/src/App/Controller/DefaultController.php
@@ -2,8 +2,10 @@
 
 namespace App\Controller;
 
+use App\Silex\Application;
 use Symfony\Component\HttpFoundation\Request;
 use App\Model\CredentialService;
+use App\Model\ForceSSLService;
 use Twig_Environment;
 
 class DefaultController
@@ -11,6 +13,7 @@ class DefaultController
     protected $app;
     protected $twig;
     protected $credentialService;
+    protected $forceSSLService;
     protected $request;
 
     /**
@@ -18,15 +21,16 @@ class DefaultController
      *
      * @param mixed $app
      * @param Twig_Environment $twig
-     * @param DoctrineConnection $db
+     * @param CredentialService $credentialService
+     * @param ForceSSLService $forceSSLService
      * @param Request $request
-     * @return void
      */
-    public function __construct($app, Twig_Environment $twig, CredentialService $credentialService, Request $request)
+    public function __construct(Application $app, Twig_Environment $twig, CredentialService $credentialService, ForceSSLService $forceSSLService, Request $request)
     {
         $this->app = $app;
         $this->twig = $twig;
         $this->credentialService = $credentialService;
+        $this->forceSSLService = $forceSSLService;
         $this->request = $request;
 
         // Clean the db on every request (workaround to not have to add cronjobs)
@@ -40,6 +44,8 @@ class DefaultController
      */
     public function indexAction()
     {
+        $this->forceSSLService->forceSSLIfSet();
+
         if ($this->request->getMethod() == 'POST') {
             $userName = $this->request->get('userName');
             $password = $this->request->get('password');
@@ -67,6 +73,8 @@ class DefaultController
      */
     public function viewLinkAction($hash)
     {
+        $this->forceSSLService->forceSSLIfSet();
+
         return $this->twig->render('view_link.twig', array(
             'hash' => $hash,
         ));
@@ -80,6 +88,8 @@ class DefaultController
      */
     public function viewPasswordAction($hash)
     {
+        $this->forceSSLService->forceSSLIfSet();
+
         $credentials = $this->credentialService->get($hash);
 
         return $this->twig->render('view_password.twig', array(

--- a/src/App/Model/ForceSSLService.php
+++ b/src/App/Model/ForceSSLService.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Model;
+
+/**
+ * Class RedirectService
+ * @package App\Model
+ */
+class ForceSSLService {
+
+    protected $forceSSL;
+
+    /**
+     * Constructor
+     *
+     * @param $config
+     */
+    public function __construct($config)
+    {
+        $this->forceSSL = $config['forceSSL'];
+    }
+
+    public function forceSSLIfSet()
+    {
+        if ($this->forceSSL)
+        {
+            $this->redirectToHTTPS();
+        }
+    }
+
+    /**
+     * Redirect
+     */
+    protected function redirectToHTTPS()
+    {
+        if($_SERVER["HTTPS"] != "on") {
+            header("HTTP/1.1 301 Moved Permanently");
+            header("Location: https://" . $_SERVER["SERVER_NAME"] . $_SERVER["REQUEST_URI"]);
+            exit();
+        }
+    }
+}


### PR DESCRIPTION
Issue 7: https://github.com/MichaelThessel/pwx/issues/7
An automatic redirect to https with config-option was needed.
I have implemented a forceSSL-Service with config-option.
Could'nt test this implementation yet.

Improvement could be to use HttpFoundation-Request instead of using $_SERVER
and use HTTPFoundation-Response for the Redirect
