### PR TITLE
Separate routingController and tests submit data

### DIFF
--- a/app/routing.php
+++ b/app/routing.php
@@ -1,7 +1,7 @@
 <?php
 
 $app->get('/', 'app.default_controller:indexAction');
-$app->post('/', 'app.default_controller:indexAction');
+$app->post('/', 'app.default_controller:indexPostAction');
 $app->get('/link/{hash}', 'app.default_controller:viewLinkAction');
 $app->get('/pw/{hash}', 'app.default_controller:viewPasswordAction');
 $app->post('/delete', 'app.default_controller:deleteAction');

--- a/src/App/Controller/DefaultController.php
+++ b/src/App/Controller/DefaultController.php
@@ -11,23 +11,19 @@ class DefaultController
     protected $app;
     protected $twig;
     protected $credentialService;
-    protected $request;
 
     /**
      * Constructor
      *
      * @param mixed $app
      * @param Twig_Environment $twig
-     * @param DoctrineConnection $db
-     * @param Request $request
-     * @return void
+     * @param CredentialService $credentialService
      */
-    public function __construct($app, Twig_Environment $twig, CredentialService $credentialService, Request $request)
+    public function __construct($app, Twig_Environment $twig, CredentialService $credentialService)
     {
         $this->app = $app;
         $this->twig = $twig;
         $this->credentialService = $credentialService;
-        $this->request = $request;
 
         // Clean the db on every request (workaround to not have to add cronjobs)
         $this->credentialService->clean();
@@ -60,7 +56,7 @@ class DefaultController
             return $this->twig->render('index.twig');
         }
 
-        $period = $this->request->get('period', 60 * 60);
+        $period = $request->get('period', 60 * 60);
         $hash = $this->credentialService->save($userName, $password, $comment, $period);
 
         return $this->app->redirect('/link/' . $hash);
@@ -101,11 +97,12 @@ class DefaultController
     /**
      * Delete an entry
      *
+     * @param Request $request
      * @return mixed Rendered Twig template
      */
-    public function deleteAction()
+    public function deleteAction(Request $request)
     {
-        $hash = $this->request->get('hash');
+        $hash = $request->get('hash');
 
         if ($hash) {
             $this->credentialService->delete($hash);

--- a/src/App/Controller/DefaultController.php
+++ b/src/App/Controller/DefaultController.php
@@ -40,23 +40,30 @@ class DefaultController
      */
     public function indexAction()
     {
-        if ($this->request->getMethod() == 'POST') {
-            $userName = $this->request->get('userName');
-            $password = $this->request->get('password');
-            $comment = $this->request->get('comment');
+        return $this->twig->render('index.twig');
+    }
 
-            // Exit if we got no password
-            if (empty($password)) {
-                return $this->twig->render('index.twig');
-            }
+    /**
+     * Submit new data
+     *
+     * @param Request $request
+     * @return mixed Rendered Twig template
+     */
+    public function indexPostAction(Request $request)
+    {
+        $userName = $request->get('userName');
+        $password = $request->get('password');
+        $comment = $request->get('comment');
 
-            $period = $this->request->get('period', 60 * 60);
-            $hash = $this->credentialService->save($userName, $password, $comment, $period);
-
-            return $this->app->redirect('/link/' . $hash);
+        // Exit if we got no password
+        if (empty($password)) {
+            return $this->twig->render('index.twig');
         }
 
-        return $this->twig->render('index.twig');
+        $period = $this->request->get('period', 60 * 60);
+        $hash = $this->credentialService->save($userName, $password, $comment, $period);
+
+        return $this->app->redirect('/link/' . $hash);
     }
 
     /**

--- a/src/App/Tests/DefaultControllerTest.php
+++ b/src/App/Tests/DefaultControllerTest.php
@@ -10,7 +10,7 @@ class DefaultControllerTest extends WebTestCase
     {
         $app = require __DIR__.'/../../../app/app.php';
 
-        $app['debug'] = true;
+        $app['debug'] = false;
 
         unset($app['exception_handler']);
 
@@ -30,5 +30,22 @@ class DefaultControllerTest extends WebTestCase
         $this->assertEquals(1, $crawler->filter('textarea[name="comment"]')->count());
         $this->assertEquals(1, $crawler->filter('select[name="period"]')->count());
         $this->assertEquals(1, $crawler->filter('button[type="submit"]')->count());
+    }
+
+    public function testPostIndex()
+    {
+        $client = $this->createClient();
+        $crawler = $client->request('GET', '/');
+        $form = $crawler->filter('#passwordSubmitForm')->form();
+        $form->setValues(array(
+            'userName' => 'nameOfUser',
+            'password' => 'passwordOfUser',
+            'comment' => 'commentOfUser',
+            'period' => 3600));
+
+        $client->submit($form);
+        $newCrawler = $client->followRedirect();
+        $this->assertTrue($client->getResponse()->isOk());
+        $this->assertContains('/pw/', $newCrawler->filter('#passwordlink')->text());
     }
 }

--- a/src/App/views/index.twig
+++ b/src/App/views/index.twig
@@ -4,7 +4,7 @@
 {% block content %}
   <div class="row">
     <div class="col-sm-12 col-md-6 col-md-offset-3 page-container">
-      <form method="post">
+      <form method="post" id="passwordSubmitForm">
         <div class="form-group">
           <label for="userName">{{ 'app.data.username'|trans }}</label>
           <input type="text" class="form-control" id="userName" name="userName" placeholder="{{ 'app.data.username'|trans }}" maxlength="255">

--- a/src/App/views/view_link.twig
+++ b/src/App/views/view_link.twig
@@ -8,7 +8,7 @@
       <div class="panel panel-default">
         <div class="panel-heading">{{ 'view_link.share'|trans }}</div>
         <div class="panel-body">
-          <span data-clipboard="{{ url }}"><a href="{{ url }}">{{ url }}</a></span>
+          <span data-clipboard="{{ url }}"><a id="passwordlink" href="{{ url }}">{{ url }}</a></span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Problem was that a form-submit in the tests doesn't submits the data correctly.
To get this problem solved, the request-Object has to be parameter of the controller function. For this the index-route is separated now to indexAction for GET and indexPostAction for POST-Requests in router.php.
To apply the Crawler-Filter in a more consistant way, the form in '/' and the link in '/link/' has css-id's.
