### PR TITLE
Prevent auto-fill in all browsers

### DIFF
--- a/src/App/views/index.twig
+++ b/src/App/views/index.twig
@@ -4,14 +4,19 @@
 {% block content %}
   <div class="row">
     <div class="col-sm-12 col-md-6 col-md-offset-3 page-container">
-      <form method="post">
+      <form method="post" autocomplete="off">
+        <div>
+          <!-- fake fields are a workaround for chrome autofill getting the wrong fields -->
+          <input style="display:none" type="text" name="fakeusernameremembered"/>
+          <input style="display:none" type="password" name="fakepasswordremembered"/>
+        </div>
         <div class="form-group">
           <label for="userName">{{ 'app.data.username'|trans }}</label>
-          <input type="text" class="form-control" id="userName" name="userName" placeholder="{{ 'app.data.username'|trans }}" maxlength="255">
+          <input type="text" class="form-control" id="userName" name="userName" placeholder="{{ 'app.data.username'|trans }}" maxlength="255" autocomplete="off">
         </div>
         <div class="form-group">
           <label for="password">{{ 'app.data.password'|trans }}</label>
-          <input type="password" class="form-control" id="password" name="password" placeholder="{{ 'app.data.password'|trans }}" required="required" maxlength="255">
+          <input type="password" class="form-control" id="password" name="password" placeholder="{{ 'app.data.password'|trans }}" required="required" maxlength="255" autocomplete="off">
           <div>
             {{ 'index.insert_password_start'|trans }}
             {% for i in 6..36 %}


### PR DESCRIPTION
For a password exchange service, the auto-filling of input fields is more annoying than it is useful.

Note: Since Chrome completely ignores the autocomplete attribute, fake hidden fields are provided as a workaround.
