### PR TITLE
Fix #51; Add missing translations: es, eo

### DIFF
--- a/app/locales/eo.yml
+++ b/app/locales/eo.yml
@@ -1,5 +1,8 @@
 app.poweredby: Funkcianta per
 app.name: Pasvort-interŝanĝo
+    
+app.meta.description: Interreta pasvort-interŝanĝa servo
+app.meta.keywords: Pasvorto, Interŝanĝo, Interrete, Akreditilo, Transdoni, Retpoŝto
 
 app.data.username: Salutnomo
 app.data.password: Pasvorto

--- a/app/locales/es.yml
+++ b/app/locales/es.yml
@@ -1,6 +1,9 @@
 app.poweredby: Funciona con
 app.name: Intercambio de contraseñas
 
+app.meta.description: Servicio para el intercambio de contraseñas a través de Internet
+app.meta.keywords: Contraseña, Intercambio, Online, En línea, Credenciales, Transferir, Email, Correo electrónico
+
 app.data.username: Nombre de usuario
 app.data.password: Contraseña
 app.data.comment: Nota


### PR DESCRIPTION
In spanish: I've translated Online and Email keywords but also left the original ones in english, since they are also commonly used, even more so than the spanish terms. And since I believe that part is intended for the search engines, that seemed like the most sensible option.
